### PR TITLE
Fixed LayerProperties Bug, Added MomentumSGD (Optimizer) and Xavier (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Softmax() # For output percentage predictions
 
 ```python
 SGD() # Stochastic Gradient Descent
+MomentumSGD() # Stochastic Gradient Descent with Momentum
 ```
 
 ## Supported Initializers
@@ -117,6 +118,7 @@ SGD() # Stochastic Gradient Descent
 Uniform() # Uniform between -1 and 1 only (at the moment)
 Normal(mean=0, std=1)
 Zero() # Zero initialized array for biases
+Xavier()
 ```
 
 ### Layer Properties

--- a/nn/__init__.py
+++ b/nn/__init__.py
@@ -23,9 +23,12 @@ from .layers.layer_properties import LayerProperties
 # Initializers
 from .initializers.normal import Normal
 from .initializers.uniform import Uniform
+from .initializers.zero import Zero
+from .initializers.xavier import Xavier
 
 # Optimizers
 from .optimizers.sgd import SGD
+from .optimizers.momentum_sgd import MomentumSGD
 
 # Loss Functions
 # Mean Squared Error

--- a/nn/initializers/__init__.py
+++ b/nn/initializers/__init__.py
@@ -1,3 +1,4 @@
 from .normal import Normal
 from .uniform import Uniform
 from .zero import Zero
+from .xavier import Xavier

--- a/nn/initializers/initializer.py
+++ b/nn/initializers/initializer.py
@@ -1,6 +1,3 @@
 class Initializer:
-    def __init__(self):
-        pass
-
     def get(self, *shape):
         raise NotImplementedError

--- a/nn/initializers/uniform.py
+++ b/nn/initializers/uniform.py
@@ -2,8 +2,5 @@ import numpy as np
 from .initializer import Initializer
 
 class Uniform(Initializer):
-    def __init__(self):
-        pass
-
     def get(self, *shape):
         return np.random.uniform(-1, 1, size=shape)

--- a/nn/initializers/xavier.py
+++ b/nn/initializers/xavier.py
@@ -1,0 +1,8 @@
+import numpy as np
+from .initializer import Initializer
+
+class Xavier(Initializer):
+    def get(self, *shape):
+        io = self.get_io_shape()
+        input_neurons = np.prod(io[0])
+        return np.random.randn(*shape) * np.sqrt(1 / input_neurons)

--- a/nn/initializers/zero.py
+++ b/nn/initializers/zero.py
@@ -2,8 +2,5 @@ import numpy as np
 from .initializer import Initializer
 
 class Zero(Initializer):
-    def __init__(self):
-        pass
-
     def get(self, *shape):
         return np.full(shape, 0, dtype="float64")

--- a/nn/layers/dense.py
+++ b/nn/layers/dense.py
@@ -3,23 +3,27 @@ from nn.layers.layer import Layer
 from nn.layers.layer_properties import LayerProperties
 from nn.initializers import *
 from nn.optimizers import *
+from copy import deepcopy
 
 class Dense(Layer):
-    # Default layer properties
-    layer_properties = LayerProperties(0.05, Uniform(), Uniform(), SGD())
 
     def __init__(self, input_shape, output_shape, layer_properties: LayerProperties = None):
-        self.weights = self.layer_properties.weight_initializer.get(output_shape, input_shape)
-        self.bias = self.layer_properties.weight_initializer.get(output_shape, 1)
+        # Default layer properties
+        self.layer_properties = LayerProperties(learning_rate=0.05, weight_initializer=Uniform(), bias_initializer=Uniform(), optimizer=SGD())
 
         # Optionally set the layer properties for all layers that utilize layer properties parameters
         if layer_properties is not None:
             # Replace all layer defaults with any non "None" layer properties.
             # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
             # Instead of forcing you to populate all the parameters every time.
-            for attr, value in layer_properties.__dict__.items():
+            for attr, _ in layer_properties.__dict__.items():
                 if getattr(layer_properties, attr) is not None:
-                    setattr(self.layer_properties, attr, getattr(layer_properties, attr))
+                    # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
+                    # optimizers such as momentum sgd require separate instances to track velocity
+                    setattr(self.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
+
+        self.weights = self.layer_properties.weight_initializer.get(output_shape, input_shape)
+        self.bias = self.layer_properties.weight_initializer.get(output_shape, 1)
 
     def forward(self, input):
         self.input = input
@@ -28,8 +32,8 @@ class Dense(Layer):
     def backward(self, output_gradient):
         weights_gradient = np.dot(output_gradient, self.input.T)
         input_gradient = np.dot(self.weights.T, output_gradient)
-        self.weights += self.layer_properties.optimizer.calc(self.layer_properties.learning_rate, weights_gradient)
-        self.bias += self.layer_properties.optimizer.calc(self.layer_properties.learning_rate, output_gradient)
+        self.weights += self.layer_properties.weight_optimizer.calc(self.layer_properties.learning_rate, weights_gradient)
+        self.bias += self.layer_properties.bias_optimizer.calc(self.layer_properties.learning_rate, output_gradient)
         return input_gradient
     
     #Helper for debug printing

--- a/nn/layers/layer_properties.py
+++ b/nn/layers/layer_properties.py
@@ -1,5 +1,6 @@
 from nn.initializers.initializer import Initializer
 from nn.optimizers.optimizer import Optimizer
+import copy
 
 class LayerProperties():
 
@@ -7,7 +8,10 @@ class LayerProperties():
         self._learning_rate = learning_rate
         self._weight_initializer = weight_initializer
         self._bias_initializer = bias_initializer
-        self._optimizer = optimizer
+        # Need independent optimizers because some optimizer require gradient shape.
+        # And the gradient can be different for the weights and biases independently.
+        self._weight_optimizer = copy.copy(optimizer)
+        self._bias_optimizer = copy.copy(optimizer)
     
     @property
     def learning_rate(self) -> int:
@@ -28,7 +32,11 @@ class LayerProperties():
         return self._bias_initializer
 
     @property
-    def optimizer(self) -> Optimizer:
-        return self._optimizer
+    def weight_optimizer(self) -> Optimizer:
+        return self._weight_optimizer
+    
+    @property
+    def bias_optimizer(self) -> Optimizer:
+        return self._bias_optimizer
     
     #Need to add setters for the initializer and optimizer and check for the class types

--- a/nn/network/network.py
+++ b/nn/network/network.py
@@ -3,6 +3,8 @@ import time
 from nn.network.training_set import TrainingSet
 from nn.layers.layer_properties import LayerProperties
 
+from copy import deepcopy
+
 class Network():
 
     # The total training time in minutes.
@@ -25,9 +27,11 @@ class Network():
                     # Replace all layer defaults with any non "None" layer properties.
                     # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
                     # Instead of forcing you to populate all the parameters every time.
-                    for attr, value in layer.layer_properties.__dict__.items():
+                    for attr, _ in layer.layer_properties.__dict__.items():
                         if getattr(layer_properties, attr) is not None:
-                            setattr(layer.layer_properties, attr, getattr(layer_properties, attr))
+                            # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
+                            # optimizers such as momentum sgd require separate instances to track velocity
+                            setattr(layer.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
 
     def predict(self, input):
         output = input
@@ -144,6 +148,7 @@ class Network():
 
         if hasattr(self, 'layer_properties'):
             print("{:<15} {}".format("Learning Rate:", str(self.layer_properties.learning_rate)))
+            print("{:<15} {}".format("Optimizer:", str(self.layer_properties._weight_optimizer.__class__.__name__)))
 
         print("{:<15} {}".format("Batch Size:", str(self.batch_size)))
         print("{:<15} {}".format("Verbose:", self.verbose))

--- a/nn/optimizers/__init__.py
+++ b/nn/optimizers/__init__.py
@@ -1,1 +1,2 @@
 from .sgd import SGD
+from .momentum_sgd import MomentumSGD

--- a/nn/optimizers/momentum_sgd.py
+++ b/nn/optimizers/momentum_sgd.py
@@ -1,0 +1,13 @@
+from .optimizer import Optimizer
+import numpy as np
+
+class MomentumSGD(Optimizer):
+    def __init__(self, mu=0.95):
+        self.mu = mu
+        self.v = None
+    
+    def calc(self, learning_rate, gradient):
+        if self.v is None:
+            self.v = np.zeros(gradient.shape)
+        self.v = self.mu * self.v + learning_rate * gradient
+        return -self.v

--- a/nn/optimizers/optimizer.py
+++ b/nn/optimizers/optimizer.py
@@ -1,6 +1,3 @@
 class Optimizer:
-    def __init__(self):
-        pass
-
     def calc(self, learning_rate, gradient):
         raise NotImplementedError

--- a/nn/optimizers/sgd.py
+++ b/nn/optimizers/sgd.py
@@ -1,8 +1,5 @@
 from .optimizer import Optimizer
 
 class SGD(Optimizer):
-    def __init__(self):
-        pass
-
     def calc(self, learning_rate, gradient):
         return -learning_rate * gradient

--- a/training_examples/mnist.py
+++ b/training_examples/mnist.py
@@ -37,9 +37,9 @@ layers = [
     Dense(35, 10),
     Softmax()
 ]
-
 # network = loadNetwork("mnist_network.pkl")
-network = Network(layers, TrainingSet(x_train, y_train, x_test, y_test, np.argmax), loss=mse, loss_prime=mse_prime, epochs=10, batch_size=1)
+network = Network(layers, TrainingSet(x_train, y_train, x_test, y_test, np.argmax), loss=mse, loss_prime=mse_prime, epochs=10, batch_size=1, \
+    layer_properties=LayerProperties(learning_rate=0.01, optimizer=MomentumSGD()))
 network.train()
 saveNetwork(network, "mnist_network.pkl")
 

--- a/training_examples/mnist_conv.py
+++ b/training_examples/mnist_conv.py
@@ -49,8 +49,10 @@ layers = [
 ]
 
 #network = loadNetwork("mnist_network_conv.pkl")
+# Setting the layer properties for every layer in the network.
+conv_layer_properties = LayerProperties(learning_rate=0.01, optimizer=MomentumSGD(), weight_initializer=Xavier())
 network = Network(layers, TrainingSet(x_train, y_train, x_test, y_test, np.argmax), loss=categorical_cross_entropy, \
-    loss_prime=categorical_cross_entropy_prime, epochs=5)
+    loss_prime=categorical_cross_entropy_prime, epochs=5, layer_properties=conv_layer_properties)
 network.train()
 saveNetwork(network, "mnist_network_conv.pkl")
 

--- a/training_examples/mnist_fcn.py
+++ b/training_examples/mnist_fcn.py
@@ -29,18 +29,19 @@ x_test, y_test = preprocess_data(x_test, y_test, 10000)
 
 # Neural Network Layers (Fully Convolutional Network)
 layers = [
-    Convolutional((1, 28, 28), 5, 5, bias_mode='tied'),
+    Convolutional((1, 28, 28), 5, 3, bias_mode='tied'),
     # Input Size = 28
     # Kernel Size = 5
     # Output Size = Input Size - Kernel Size + 1
     # 28 - 5 + 1 = 24
     Sigmoid(),
     Dropout(0.25),
-    Convolutional((5, 24, 24), 3, 5, bias_mode='tied'),
+    # the first input parameter in "3" in (3, 24, 24) is the kernel depth of the previous layer
+    Convolutional((3, 24, 24), 3, 2, bias_mode='tied'),
     Sigmoid(),
-    Convolutional((5, 22, 22), 3, 5, bias_mode='tied'),
+    Convolutional((2, 22, 22), 3, 2, bias_mode='tied'),
     Sigmoid(),
-    Convolutional((5, 20, 20), 20, 10, bias_mode='tied'),
+    Convolutional((2, 20, 20), 20, 10, bias_mode='tied'),
     # The flatten is only necessary because the convolutional layer implementation uses 2d convolution functions.
     # So it can't backprop to 3d properly without a flatten layer.
     Flatten((10, 1, 1)),


### PR DESCRIPTION
Fixed LayerProperties Bug, Added MomentumSGD (Optimizer) and Xavier (Initializer)

Added the MomentumSGD optimizer and the Xavier weight intializer. LayerProperties members were getting propagated as one shared object instead of individual objects for each layer.  This caused the same optimizer object to be passed to every single layer in the network causing errors because they needed independent internal state. I fixed this by making deep copies of the individual attributes on initialization. I also made the layer properties themselves to be instance variables of the layers instead of class variables.