### PR TITLE
Optimized MaxPooling Forward Pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Convolutional((inputDepth, inputWidth, inputHeight), kernelSize, numKernels)
 Reshape() # Modifies the shape of the numpy arrays passed between layers
 Flatten() # Flattens a numpy array into a 2D matrix with a single column
 Dropout(probability) # Randomly drops layer outputs based on a probability to prevent overfitting
-# MaxPooling2D is slightly inefficient at the moment, but it is a working implementation.
+# Max pooling kernel size currently only takes an integer to make a square kernel
 MaxPooling2D((inputDepth, inputWidth, inputHeight), kernelSize, stride=(int, int), padding=(int, int))
 
 # Activation Functions

--- a/training_examples/mnist_maxpooling.py
+++ b/training_examples/mnist_maxpooling.py
@@ -1,5 +1,3 @@
-# DISCLAIMER The Maxpooling class still needs to be optimized further. This example will take about 15 mins to run on a modern cpu.
-
 import sys
 sys.path.append('..')
 


### PR DESCRIPTION
Optimized the forward pass of the max pooling by eliminating np.unravel_index and calculating the input index myself. This gives a 3x performance increase from my original implementation. So instead of a model with maxpooling training in 12 mins, it will now train in 4 mins.