### PR TITLE
Add Sanity Checks, Allow More Kernel And Padding Formats, Revise README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ python mnist_conv.py
 python mnist_fcn.py
 
 # Convolutional neural network implementation for mnist with max pooling
-# Max pooling still needs some optimization so it runs a bit slow currently
 python mnist_maxpooling.py
 ```
 ---
@@ -97,13 +96,13 @@ post_processing is a function applied to your network prediction and training se
 ## Supported Neural Layers
 
 ```python
-Dense(numInputNeurons, numOutputNeurons) # For weight manipulation
-Convolutional((inputDepth, inputWidth, inputHeight), kernelSize, numKernels, stride=(int, int), padding=((int, int), (int, int)))
+# Layers
+Dense(num_input_neurons, num_output_neurons) # For weight manipulation
+Convolutional((input_depth, input_height, input_width), kernel_size, num_kernels, stride=(int, int), padding=((int, int), (int, int)))
 Reshape() # Modifies the shape of the numpy arrays passed between layers
 Flatten() # Flattens a numpy array into a 2D matrix with a single column
-Dropout(probability) # Randomly drops layer outputs based on a probability to prevent overfitting
-# Max pooling kernel size currently only takes an integer to make a square kernel
-MaxPooling2D((inputDepth, inputWidth, inputHeight), kernelSize=(int, int), stride=(int, int), padding=((int, int), (int, int)))
+Dropout(probability) # Randomly drops layer outputs based on a probability to prevent overfitting. A probability of 0.25 would drop 25% of connections.
+MaxPooling2D((input_depth, input_height, input_width), kernel_size, stride=(int, int), padding=((int, int), (int, int)))
 
 # Activation Functions
 Sigmoid()
@@ -174,30 +173,45 @@ network = Network(
 )
 ```
 
-## Stride and Padding Notation
+## Kernel, Stride, and Padding Notation
 > :warning: Striding and Padding were only recently implemented. I cannot confirm that they work in all cases yet. So use at your own risk.
 
 Sometimes you might see notation like **array[x][y]**. However, this is kind of a confusing syntax that people (including myself) write. Do not confuse the arbitrary variable **x** with the width. It does not represent the "x" of a coordinate system; in reality it represents the height. If you view the array syntax from a coordinate perspective it is really **array[height][width]**. So when you are inputting parameters for strides and padding it is really with the syntax **(height, width)**.
 
+### Kernel
+
+The kernel supports 3 different syntax listed below. 
+
+```
+kernel_size = 3         # Uses 3 for the height and width
+kernel_size = (3)       # Uses 3 for the height and width
+kernel_size = (3,3)
+```
+
 ### Striding
 
-Striding only has two dimensions, that is striding in the "height" dimension and striding in the "width" dimension. Striding follows the syntax **(height_stride, width_stride)**. So a stride of (2,3) would move the kernel 2 positions to the right or 3 positions down.
+Striding only has two dimensions, that is striding in the "height" dimension and striding in the "width" dimension. Striding follows the syntax **(height_stride, width_stride)**. So a stride of (2,3) would move the kernel 2 positions to the right or 3 positions down. Syntax example listed below.
+
+```
+stride = (3, 3)
+```
 
 ### Padding
 
-There are two different allowed padding formats.
+There are four different allowed padding formats.
 
 **(pad_all_4_sides)**  
-```padding = (0)```
+```padding = 1```
 or...
-```padding = 0```
+```padding = (1)```
 
-**((top_height_pad,bottom_height_pad), (left_width_pad,right_width_pad))**  
+**(pad_height, pad_width)**  
+```padding = (1, 1)```
+
+**((pad_top_height,pad_bottom_height), (pad_left_width,pad_right_width))**  
 Alternatively you could think of the format as...  
 **((top, bottom), (left, right))**  
 ```padding = ((1,1), (2,2))```
-
-The syntax (1,2) **IS NOT SUPPORTED**.
 
 ## CUDA Support
 

--- a/nn/layers/convolutional.py
+++ b/nn/layers/convolutional.py
@@ -9,54 +9,28 @@ from typing import Tuple
 
 class Convolutional(Layer):
 
-    def __init__(self, input_shape, kernel_size: int, depth: int, stride: Tuple[int,int]= (1,1), padding = (0), bias_mode: str = 'untied', layer_properties: LayerProperties = None):
+    def __init__(self, input_shape, kernel_size, kernel_depth: int, stride: Tuple[int,int]= (1,1), padding = (0), bias_mode: str = 'untied', layer_properties: LayerProperties = None):
         # Default layer properties
         self.layer_properties = LayerProperties(learning_rate=0.05, weight_initializer=Uniform(), bias_initializer=Uniform(), optimizer=SGD())
 
-        # Optionally set the layer properties for all layers that utilize layer properties parameters
-        if layer_properties is not None:
-            # Replace all layer defaults with any non "None" layer properties.
-            # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
-            # Instead of forcing you to populate all the parameters every time.
-            for attr, _ in layer_properties.__dict__.items():
-                if getattr(layer_properties, attr) is not None:
-                    # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
-                    # optimizers such as momentum sgd require separate instances to track velocity
-                    setattr(self.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
+        # Parse and update any optional layer properties
+        self.parse_layer_properties(layer_properties)
 
-        input_depth, input_height, input_width = input_shape
-        self.depth = depth
+        self.kernel_depth = kernel_depth
         self.input_shape = input_shape
-        self.input_depth = input_depth
-        self.kernel_size = kernel_size
-        self.kernels_shape = (depth, input_depth, kernel_size, kernel_size)
+        self.input_depth = input_shape[0]
+        self.kernel_size = self.parse_kernel(kernel_size)
+        self.kernels_shape = (self.kernel_depth, self.input_depth, self.kernel_size[0], self.kernel_size[1])
         self.kernels = self.layer_properties.weight_initializer.get(*self.kernels_shape)
 
         self.stride = stride
-        # checks for single integer
-        if isinstance(padding, int):
-            # The extra tuple of zeros is for the depth dimension which needs no padding.
-            self.padding = ((0, 0), (padding, padding), (padding, padding))
-        # checks for single value in tuple
-        elif isinstance(padding, tuple) and len(padding) == 1:
-            self.padding = ((0, 0), (padding[0], padding[0]), (padding[0], padding[0]))
-        # Otherwise it just sets the values. 2D tuple with 4 values.
-        else:
-            self.padding = ((0, 0), (padding[0][0], padding[0][1]), (padding[1][0], padding[1][1]))
+        # Parse the padding into a 3D tuple ((padding_height1, padding_width1), (padding_height2, padding_width2), (padding_height2, padding_width2))
+        # One tuple pair for each dimension. (depth, kernel height, kernel width)
+        self.padding = self.parse_padding(padding)
 
-        # Error checking to make sure the kernel and stride can evenly map across the input.
-        dimension_1 = (input_shape[1] - self.kernel_size + (self.padding[1][0] + self.padding[1][1])) / self.stride[0] + 1
-        dimension_2 = (input_shape[2] - self.kernel_size + (self.padding[2][0] + self.padding[2][1])) / self.stride[1] + 1
-        if not dimension_1.is_integer() or not dimension_2.is_integer():
-            raise ValueError("(input_size - kernel_size + (2 * padding)) / stride ... must be an integer.\n" \
-                            "dimension 0 = depth\n" \
-                            "dimension 1 = input height\n" \
-                            "dimension 2 = input width\n" \
-                            "This library does not handle cropping inputs for kernels / strides that do not evenly divide the input.")
-
-        self.output_shape = (self.depth,
-                            (self.input_shape[1] - self.kernel_size + (self.padding[1][0] + self.padding[1][1])) // self.stride[0] + 1,
-                            (self.input_shape[2] - self.kernel_size + (self.padding[2][0] + self.padding[2][1])) // self.stride[1] + 1)
+        self.output_shape = (self.kernel_depth,
+                            (self.input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) // self.stride[0] + 1,
+                            (self.input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) // self.stride[1] + 1)
 
         valid_bias_modes = {'tied', 'untied'}
         if bias_mode not in valid_bias_modes:
@@ -66,7 +40,10 @@ class Convolutional(Layer):
         if bias_mode == 'untied':
             self.biases = self.layer_properties.bias_initializer.get(*self.output_shape)
         elif bias_mode == 'tied':
-            self.biases = self.layer_properties.bias_initializer.get(self.depth, 1, 1)
+            self.biases = self.layer_properties.bias_initializer.get(self.kernel_depth, 1, 1)
+        
+        # Run sanity checks to eliminate input errors
+        self.sanity_checks()
 
     def forward(self, input):
         if self.bias_mode == 'untied':
@@ -87,7 +64,7 @@ class Convolutional(Layer):
         input = np.pad(input, self.padding, mode='constant')
         self.input = input
         self.output = np.copy(self.biases)
-        for i in range(self.depth):
+        for i in range(self.kernel_depth):
             for j in range(self.input_depth):
                 self.output[i] += signal.correlate2d(input[j], self.kernels[i, j], "valid")[::self.stride[0], ::self.stride[1]]
         return self.output
@@ -96,10 +73,11 @@ class Convolutional(Layer):
         # https://medium.com/@mayank.utexas/backpropagation-for-convolution-with-strides-8137e4fc2710
         # link to the dilation concept is above
         # The output gradient must be dilated before it can be correlated with the input due to striding.
-        depth, x, y = output_gradient.shape
+        # The 1 * min is basically just a toggle. Because in the case of a stride of 1 you do NOT want to subtract 1 or dilate the output.
+        depth, height, width = output_gradient.shape
         dilated_output_gradient = np.zeros((depth,
-                        x + ((self.stride[0] - 1) * x - (1 * min(self.stride[0] - 1, 1))),
-                        y + ((self.stride[1] - 1) * y - (1 * min(self.stride[1] - 1, 1)))),
+                        height + ((self.stride[0] - 1) * height - (1 * min(self.stride[0] - 1, 1))),
+                        width + ((self.stride[1] - 1) * width - (1 * min(self.stride[1] - 1, 1)))),
                         dtype=output_gradient.dtype)
         dilated_output_gradient[::, ::self.stride[0], ::self.stride[1]] = output_gradient
 
@@ -118,7 +96,7 @@ class Convolutional(Layer):
 
         kernels_gradient = np.zeros(self.kernels_shape)
         input_gradient = np.zeros(self.input_shape)
-        for i in range(self.depth):
+        for i in range(self.kernel_depth):
             for j in range(self.input_depth):
                 kernels_gradient[i, j] = signal.correlate2d(self.input[j], dilated_output_gradient[i], "valid")
                 input_gradient[j] += signal.convolve2d(dilated_trunc_output_gradient[i], self.kernels[i, j], "full")
@@ -131,17 +109,17 @@ class Convolutional(Layer):
         input = np.pad(input, self.padding, mode='constant')
         self.input = input
         self.output = np.zeros(self.output_shape)
-        for i in range(self.depth):
+        for i in range(self.kernel_depth):
             for j in range(self.input_depth):
                 self.output[i] += signal.correlate2d(self.input[j], self.kernels[i, j], "valid")[::self.stride[0], ::self.stride[1]]
             self.output[i] += self.biases[i]
         return self.output
 
     def backward_tied(self, output_gradient):
-        depth, x, y = output_gradient.shape
+        depth, height, width = output_gradient.shape
         dilated_output_gradient = np.zeros((depth,
-                        x + ((self.stride[0] - 1) * x - (1 * min(self.stride[0] - 1, 1))),
-                        y + ((self.stride[1] - 1) * y - (1 * min(self.stride[1] - 1, 1)))),
+                        height + ((self.stride[0] - 1) * height - (1 * min(self.stride[0] - 1, 1))),
+                        width + ((self.stride[1] - 1) * width - (1 * min(self.stride[1] - 1, 1)))),
                         dtype=output_gradient.dtype)
         dilated_output_gradient[::, ::self.stride[0], ::self.stride[1]] = output_gradient
 
@@ -159,7 +137,7 @@ class Convolutional(Layer):
 
         kernels_gradient = np.zeros(self.kernels_shape)
         input_gradient = np.zeros(self.input_shape)
-        for i in range(self.depth):
+        for i in range(self.kernel_depth):
             for j in range(self.input_depth):
                 kernels_gradient[i, j] = signal.correlate2d(self.input[j], dilated_output_gradient[i], "valid")
                 input_gradient[j] += signal.convolve2d(dilated_trunc_output_gradient[i], self.kernels[i, j], "full")
@@ -167,15 +145,87 @@ class Convolutional(Layer):
         # Sum all the gradients for the output gradient of each kernel then multiply by the learning rate.
         self.biases += self.layer_properties.bias_optimizer.calc(self.layer_properties.learning_rate, np.sum(output_gradient, keepdims=True, axis=(1,2)))
         return input_gradient
+    
+    def parse_kernel(self, kernel):
+        # checks for single integer
+        if isinstance(kernel, int):
+            return (kernel, kernel)
+        # checks for single value in tuple
+        elif isinstance(kernel, tuple) and len(kernel) == 1:
+            return (kernel[0], kernel[0])
+        elif isinstance(kernel, tuple) and len(kernel) == 2:
+            # No changes necessary if tuple with 2 values.
+            return kernel
+        else:
+            raise ValueError("Kernel size invalid. Please use one of the following formats...\n" \
+                            "kernel_size = 3\n" \
+                            "kernel_size = (3)\n" \
+                            "kernel_size = (3,3)\n")
+    
+    def parse_padding(self, padding):
+        # checks for single integer
+        if isinstance(padding, int):
+            # The extra tuple of zeros is for the depth dimension which needs no padding.
+            return ((0, 0), (padding, padding), (padding, padding))
+        # checks for single value in tuple
+        elif isinstance(padding, tuple) and len(padding) == 1:
+            return ((0, 0), (padding[0], padding[0]), (padding[0], padding[0]))
+        elif isinstance(padding, tuple) and len(padding) == 2:
+            # (height, width) or (3, 3)
+            if isinstance(padding[0], int) and isinstance(padding[1], int):
+                return ((0, 0), (padding[0], padding[0]), (padding[1], padding[1]))
+            # ((top, bottom), (left, right))
+            elif isinstance(padding[0], tuple) and isinstance(padding[1], tuple) and len(padding[0]) == 2 and len(padding[1]) == 2:
+                return ((0, 0), (padding[0][0], padding[0][1]), (padding[1][0], padding[1][1]))
+        else:
+            raise ValueError("Padding size invalid. Please use one of the following formats...\n" \
+                            "padding = 3\n" \
+                            "padding = (3)\n" \
+                            "padding = (3,3)\n" \
+                            "padding = ((3,3), (3,3))\n")
+    
+    def parse_layer_properties(self, layer_properties):
+        # Optionally set the layer properties for all layers that utilize layer properties parameters
+        if layer_properties is not None:
+            # Replace all layer defaults with any non "None" layer properties.
+            # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
+            # Instead of forcing you to populate all the parameters every time.
+            for attr, _ in layer_properties.__dict__.items():
+                if getattr(layer_properties, attr) is not None:
+                    # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
+                    # optimizers such as momentum sgd require separate instances to track velocity
+                    setattr(self.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
+
+    def sanity_checks(self):
+        # Error checking to make sure the kernel and stride can evenly map across the input.
+        dimension_1 = (self.input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) / self.stride[0] + 1
+        dimension_2 = (self.input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) / self.stride[1] + 1
+        if not dimension_1.is_integer() or not dimension_2.is_integer():
+            raise ValueError("(input_size - kernel_size + (2 * padding)) / stride ... must be an integer.\n" \
+                            "dimension 0 = depth\n" \
+                            "dimension 1 = input height\n" \
+                            "dimension 2 = input width\n" \
+                            "This library does not handle cropping inputs for kernels / strides that do not evenly divide the input.")
+        
+        # If the padding is larger than the kernel size then you have values that will always be zero.
+        # Because the output will only be calculated based on padding and not any input data
+        if self.padding[1][0] >= self.kernel_size[0]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[1][0], self.kernel_size))
+        elif self.padding[1][1] >= self.kernel_size[0]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[1][1], self.kernel_size))
+        elif self.padding[2][0] >= self.kernel_size[1]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[2][0], self.kernel_size))
+        elif self.padding[2][1] >= self.kernel_size[1]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[2][1], self.kernel_size))
 
     # Modify string representation for network architecture printing
     def __str__(self):
-        return self.__class__.__name__ + "(({}, {}, {}), kernel_size = {}, depth = {}, bias_mode = {}, stride = {}, padding = {})".format(
+        return self.__class__.__name__ + "(({}, {}, {}), kernel_size = {}, kernel_depth = {}, bias_mode = {}, stride = {}, padding = {})".format(
             self.input_shape[0],
             self.input_shape[1],
             self.input_shape[2],
-            self.kernels_shape[3],
-            self.depth,
+            self.kernel_size,
+            self.kernel_depth,
             self.bias_mode,
             self.stride,
             self.padding[1:]

--- a/nn/layers/dense.py
+++ b/nn/layers/dense.py
@@ -11,16 +11,8 @@ class Dense(Layer):
         # Default layer properties
         self.layer_properties = LayerProperties(learning_rate=0.05, weight_initializer=Uniform(), bias_initializer=Uniform(), optimizer=SGD())
 
-        # Optionally set the layer properties for all layers that utilize layer properties parameters
-        if layer_properties is not None:
-            # Replace all layer defaults with any non "None" layer properties.
-            # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
-            # Instead of forcing you to populate all the parameters every time.
-            for attr, _ in layer_properties.__dict__.items():
-                if getattr(layer_properties, attr) is not None:
-                    # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
-                    # optimizers such as momentum sgd require separate instances to track velocity
-                    setattr(self.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
+        # Parse and update any optional layer properties
+        self.parse_layer_properties(layer_properties)
 
         self.weights = self.layer_properties.weight_initializer.get(output_shape, input_shape)
         self.bias = self.layer_properties.weight_initializer.get(output_shape, 1)
@@ -36,6 +28,18 @@ class Dense(Layer):
         self.bias += self.layer_properties.bias_optimizer.calc(self.layer_properties.learning_rate, output_gradient)
         return input_gradient
     
+    def parse_layer_properties(self, layer_properties):
+        # Optionally set the layer properties for all layers that utilize layer properties parameters
+        if layer_properties is not None:
+            # Replace all layer defaults with any non "None" layer properties.
+            # This is just a lot of fancy code to allow you to override only 'some' of the default layer properties.
+            # Instead of forcing you to populate all the parameters every time.
+            for attr, _ in layer_properties.__dict__.items():
+                if getattr(layer_properties, attr) is not None:
+                    # copy is necessary to ensure that individual layer classes don't get shared instances of an optimizer
+                    # optimizers such as momentum sgd require separate instances to track velocity
+                    setattr(self.layer_properties, attr, deepcopy(getattr(layer_properties, attr)))
+
     # Modify string representation for network architecture printing
     def __str__(self):
         return self.__class__.__name__ + "({}, {})".format(self.weights.shape[1], self.weights.shape[0])

--- a/nn/layers/maxpooling2d.py
+++ b/nn/layers/maxpooling2d.py
@@ -17,46 +17,23 @@ from numpy.lib.stride_tricks import as_strided
 # The max pooling layer does not change the depth of the input. And it has no trainable parameters.
 class MaxPooling2D(Layer):
 
-    def __init__(self, input_shape, kernel_size: Tuple[int,int]= (2,2), stride: Tuple[int,int]= (2,2), padding = (0)):
+    def __init__(self, input_shape, kernel_size, stride: Tuple[int,int]= (2,2), padding = (0)):
         self.input_shape = input_shape
-        self.kernel_size = kernel_size
-        self.depth = input_shape[0]
+        self.kernel_size = self.parse_kernel(kernel_size)
         self.stride = stride
-
-        # padding supports two padding formats depending on how you want to pad the various sides.
-        # 2 or (2). Pads all sides
-        # ((top, bottom), (left, right))
-        # ((1,2),(2,1)). Pads sides individually
-        
-        # checks for single integer
-        if isinstance(padding, int):
-            # The extra tuple of zeros is for the depth dimension which needs no padding.
-            self.padding = ((0, 0), (padding, padding), (padding, padding))
-        # checks for single value in tuple
-        elif isinstance(padding, tuple) and len(padding) == 1:
-            self.padding = ((0, 0), (padding[0], padding[0]), (padding[0], padding[0]))
-        # Otherwise it just sets the values. 2D tuple with 4 values.
-        else:
-            self.padding = ((0, 0), (padding[0][0], padding[0][1]), (padding[1][0], padding[1][1]))
-
-        # Error checking to make sure the kernel and stride can evenly map across the input.
-        dimension_1 = (input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) / self.stride[0] + 1
-        dimension_2 = (input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) / self.stride[1] + 1
-        if not dimension_1.is_integer() or not dimension_2.is_integer():
-            raise ValueError("(input_size - kernel_size + (2 * padding)) / stride ... must be an integer.\n" \
-                            "dimension 0 = depth\n" \
-                            "dimension 1 = input height\n" \
-                            "dimension 2 = input width\n" \
-                            "This library does not handle cropping inputs for kernels / strides that do not evenly divide the input.")
+        self.padding = self.parse_padding(padding)
         
         # The final output shape of the MaxPooling layer
-        self.output_shape = (input_shape[0], 
-                            (input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) // self.stride[0] + 1,
-                            (input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) // self.stride[1] + 1)
+        self.output_shape = (self.input_shape[0], 
+                            (self.input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) // self.stride[0] + 1,
+                            (self.input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) // self.stride[1] + 1)
         # This index map contains the input indexes that the output gradient maps to.
         # Basically the value at index_map[depth][x][y] is coordinates to the input that output_gradient[depth][x][y] needs to be applied to.
-        self.index_map_x = np.zeros((self.depth, self.output_shape[1], self.output_shape[2]), dtype="int")
-        self.index_map_y = np.zeros((self.depth, self.output_shape[1], self.output_shape[2]), dtype="int")
+        self.index_map_x = np.zeros((self.output_shape[0], self.output_shape[1], self.output_shape[2]), dtype="int")
+        self.index_map_y = np.zeros((self.output_shape[0], self.output_shape[1], self.output_shape[2]), dtype="int")
+
+        # Run sanity checks to eliminate input errors
+        self.sanity_checks()
 
     def forward(self, input):
         # Padding. Have to pad with negative infinity for max pooling.
@@ -65,7 +42,7 @@ class MaxPooling2D(Layer):
         
         # The array is 5D because it correlates each stride calculated with each output. (depth, output_x, output_y, stride_result_x, stride_result_y)
         # This is a pre-processing step so we can call the max function on each stride output and map them to the output shape.
-        view_shape = (self.depth, self.output_shape[1], self.output_shape[2], self.kernel_size[0], self.kernel_size[1])
+        view_shape = (self.output_shape[0], self.output_shape[1], self.output_shape[2], self.kernel_size[0], self.kernel_size[1])
         # The strides that will be applied to the input array
         view_strides = (input.strides[0], self.stride[0] * input.strides[1], self.stride[1] * input.strides[2], input.strides[1], input.strides[2])
         
@@ -100,7 +77,7 @@ class MaxPooling2D(Layer):
         indices_x = indices[0] * self.stride[0]
         indices_y = indices[1] * self.stride[1]
         # Loop through the depth of the input and apply the mask calculation to each input depth
-        for depth in range(self.depth):
+        for depth in range(self.output_shape[0]):
             # Final calculation of the local_stride_index added with the (stride output coordinate * stride size)
             self.index_map_x[depth] = argmax_arr_x[depth] + indices_x
             self.index_map_y[depth] = argmax_arr_y[depth] + indices_y
@@ -124,6 +101,70 @@ class MaxPooling2D(Layer):
                     # if the stride is smaller than the pooling size.
                     input_gradient[depth][input_x_index][input_y_index] += output_gradient[depth][x][y]
         return input_gradient
+    
+    def parse_kernel(self, kernel):
+        # checks for single integer
+        if isinstance(kernel, int):
+            return (kernel, kernel)
+        # checks for single value in tuple
+        elif isinstance(kernel, tuple) and len(kernel) == 1:
+            return (kernel[0], kernel[0])
+        elif isinstance(kernel, tuple) and len(kernel) == 2:
+            # No changes necessary if tuple with 2 values.
+            return kernel
+        else:
+            raise ValueError("Kernel size invalid. Please use one of the following formats...\n" \
+                            "kernel_size = 3\n" \
+                            "kernel_size = (3)\n" \
+                            "kernel_size = (3,3)\n")
+
+    # padding supports two padding formats depending on how you want to pad the various sides.
+    # 2 or (2). Pads all sides
+    # ((top, bottom), (left, right))
+    # ((1,2),(2,1)). Pads sides individually
+    def parse_padding(self, padding):
+        # checks for single integer
+        if isinstance(padding, int):
+            # The extra tuple of zeros is for the depth dimension which needs no padding.
+            return ((0, 0), (padding, padding), (padding, padding))
+        # checks for single value in tuple
+        elif isinstance(padding, tuple) and len(padding) == 1:
+            return ((0, 0), (padding[0], padding[0]), (padding[0], padding[0]))
+        elif isinstance(padding, tuple) and len(padding) == 2:
+            # (height, width) or (3, 3)
+            if isinstance(padding[0], int) and isinstance(padding[1], int):
+                return ((0, 0), (padding[0], padding[0]), (padding[1], padding[1]))
+            # ((top, bottom), (left, right))
+            elif isinstance(padding[0], tuple) and isinstance(padding[1], tuple) and len(padding[0]) == 2 and len(padding[1]) == 2:
+                return ((0, 0), (padding[0][0], padding[0][1]), (padding[1][0], padding[1][1]))
+        else:
+            raise ValueError("Padding size invalid. Please use one of the following formats...\n" \
+                            "padding = 3\n" \
+                            "padding = (3)\n" \
+                            "padding = (3,3)\n" \
+                            "padding = ((3,3), (3,3))\n")
+
+    def sanity_checks(self):
+        # Error checking to make sure the kernel and stride can evenly map across the input.
+        dimension_1 = (self.input_shape[1] - self.kernel_size[0] + (self.padding[1][0] + self.padding[1][1])) / self.stride[0] + 1
+        dimension_2 = (self.input_shape[2] - self.kernel_size[1] + (self.padding[2][0] + self.padding[2][1])) / self.stride[1] + 1
+        if not dimension_1.is_integer() or not dimension_2.is_integer():
+            raise ValueError("(input_size - kernel_size + (2 * padding)) / stride ... must be an integer.\n" \
+                            "dimension 0 = depth\n" \
+                            "dimension 1 = input height\n" \
+                            "dimension 2 = input width\n" \
+                            "This library does not handle cropping inputs for kernels / strides that do not evenly divide the input.")
+        
+        # If the padding is larger than the kernel size then you have values that will always be zero.
+        # Because the output will only be calculated based on padding and not any input data
+        if self.padding[1][0] >= self.kernel_size[0]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[1][0], self.kernel_size))
+        elif self.padding[1][1] >= self.kernel_size[0]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[1][1], self.kernel_size))
+        elif self.padding[2][0] >= self.kernel_size[1]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[2][0], self.kernel_size))
+        elif self.padding[2][1] >= self.kernel_size[1]:
+            raise ValueError("Padding size {} is greater than or equal to kernel size {}".format(self.padding[2][1], self.kernel_size))
 
     # Modify string representation for network architecture printing
     def __str__(self):

--- a/training_examples/mnist_conv_stride.py
+++ b/training_examples/mnist_conv_stride.py
@@ -48,7 +48,7 @@ layers = [
 
 #network = loadNetwork("mnist_network_conv.pkl")
 # Setting the layer properties for every layer in the network.
-conv_layer_properties = LayerProperties(learning_rate=0.01, optimizer=MomentumSGD(), weight_initializer=Normal(), bias_initializer=Zero())
+conv_layer_properties = LayerProperties(learning_rate=0.005, optimizer=MomentumSGD(), weight_initializer=Normal(std=0.1), bias_initializer=Zero())
 network = Network(
     layers,
     TrainingSet(x_train, y_train, x_test, y_test, np.argmax),

--- a/training_examples/mnist_fcn.py
+++ b/training_examples/mnist_fcn.py
@@ -42,8 +42,8 @@ layers = [
     Convolutional((2, 22, 22), 3, 2, bias_mode='tied'),
     Sigmoid(),
     Convolutional((2, 20, 20), 20, 10, bias_mode='tied'),
-    # The flatten is only necessary because the convolutional layer implementation uses 2d convolution functions.
-    # So it can't backprop to 3d properly without a flatten layer.
+    # The flatten is only necessary because the Softmax layer takes 1D input.
+    # So it can't forward prop or backprop to 3D properly without a flatten layer.
     Flatten((10, 1, 1)),
     Softmax()
 ]


### PR DESCRIPTION
Refactored variable names in both the convolution and maxpooling2d classes. Added sanity checks for input sizes, padding, strides, etc to avoid input errors. Revised the readme with the newest parameter changes to the stride, kernel, and padding formats. Added helper functions for kernel size parsing, padding size parsing, and layer property parsing.